### PR TITLE
fix: point package main to dist entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apigee-templater",
   "version": "4.5.7",
   "description": "Provides tooling for feature development of Apigee proxies using YAML, JSON and ZIP formats, and REST, MCP & CLI interfaces.",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "directories": {
     "doc": "docs",
     "example": "examples"


### PR DESCRIPTION
## Summary
- Updates the package `main` field from the unpublished root `index.js` path to the published `./dist/index.js` entrypoint.
- Keeps the existing build output and `files: ["dist/"]` package layout intact.

## Reproduction
Published `apigee-templater@4.5.7` currently resolves the package root to a file that is not included in the npm tarball:

```sh
tmp=$(mktemp -d)
cd "$tmp"
npm init -y >/dev/null
npm install apigee-templater@4.5.7 --ignore-scripts --no-audit --no-fund
node --input-type=module -e "console.log(await import.meta.resolve('apigee-templater'))"
```

Observed:

```text
ERR_MODULE_NOT_FOUND: Cannot find package '.../node_modules/apigee-templater/index.js'
```

## Validation
- `npm run build` ✅
- `npm pack --dry-run --json --ignore-scripts` ✅ verified `dist/index.js` is included in packed files
- Installed the locally packed tarball into a clean temp project and verified `import.meta.resolve('apigee-templater')` resolves to `node_modules/apigee-templater/dist/index.js`
- `git diff --check` ✅

Note: `npm test` currently builds successfully but exits with Vitest code 1 because the repository has no matching test files. I did not change that behavior.
